### PR TITLE
Fix: Nested OrderBy

### DIFF
--- a/subgrounds/contrib/pyodide.py
+++ b/subgrounds/contrib/pyodide.py
@@ -8,12 +8,13 @@ import warnings
 
 __all__ = ["patch"]
 
+
 def patch():
     """Attempts to patch `requests` to allow `subgrounds` to work in `pyodide`
-    
+
     Outputs warnings instead of exceptions when things go wrong
     """
-    
+
     if "pyodide" in sys.modules:
         try:
             import pyodide_http
@@ -24,11 +25,8 @@ def patch():
                 "    `pip install subgrounds[pyodide]`"
             )
             return
-        
+
         try:
             pyodide_http.patch_all()
         except Exception as e:
-            warnings.warn(
-                "Failed to patch with `pyodide-http`:\n"
-                + str(e)
-            )
+            warnings.warn("Failed to patch with `pyodide-http`:\n" + str(e))

--- a/subgrounds/pagination/strategies.py
+++ b/subgrounds/pagination/strategies.py
@@ -73,7 +73,6 @@ from ast import Tuple
 from dataclasses import dataclass, field
 from functools import partial
 from itertools import count
-from pprint import pprint
 from typing import Any, Callable, Iterator, Literal, Optional
 
 from pipe import map, traverse
@@ -137,7 +136,11 @@ class LegacyStrategyArgGenerator:
             # Current node step
             index_field_data = list(
                 extract_data(
-                    [*self.page_node.key_path, self.page_node.filter_field], data
+                    [
+                        *self.page_node.key_path,
+                        *self.page_node.filter_field.split("__"),
+                    ],
+                    data,
                 )
                 | traverse
             )
@@ -259,7 +262,7 @@ class LegacyStrategy:
 
     def step(
         self, page_data: Optional[dict[str, Any]] = None
-    ) -> Tuple[Document, dict[str, Any]]:
+    ) -> tuple[Document, dict[str, Any]]:
         args = self.arg_generator.step(page_data)
         trimmed_doc = prune_doc(self.normalized_doc, args)
         return (trimmed_doc, args)

--- a/subgrounds/schema.py
+++ b/subgrounds/schema.py
@@ -305,17 +305,6 @@ class TypeMeta:
                 TypeRef.T: The type reference for input field `fname`
             """
 
-            def print2(thing):
-                print(thing)
-                return thing
-            
-            for field in self.input_fields:
-                if field.name == fname:
-                    return field.type_
-
-                if field.type_ is TypeMeta.InputObjectMeta:
-                    field.name
-
             try:
                 return next(
                     self.input_fields
@@ -393,7 +382,7 @@ class SchemaMeta(BaseModel):
 
         return values
 
-    def type_of_typeref(self: SchemaMeta, typeref: TypeRef.T) -> TypeMeta.T:
+    def type_of_typeref(self: SchemaMeta, typeref: TypeRef.T) -> TypeMeta_T:
         """Returns the type information of the type reference `typeref`
 
         Args:
@@ -417,7 +406,23 @@ class SchemaMeta(BaseModel):
 
     def type_of(
         self: SchemaMeta, tmeta: TypeMeta.ArgumentMeta | TypeMeta.FieldMeta
-    ) -> TypeMeta.T:
+    ) -> TypeMeta_T:
         """Returns the argument or field definition's underlying type"""
 
         return self.type_of_typeref(tmeta.type_)
+
+    def type_of_input_object_meta(
+        self, tmeta: TypeMeta.InputObjectMeta, args: list[str]
+    ) -> TypeRef.T:
+        """Recursively finds the nested type"""
+
+        if len(args) < 1:
+            raise Exception("type_of_input_object_meta: TODO")
+
+        type_ref = tmeta.type_of_input_field(args.pop(0))
+        match self.type_of_typeref(type_ref):
+            case TypeMeta.InputObjectMeta() as tmeta:
+                return self.type_of_input_object_meta(tmeta, args)
+
+            case _:
+                return type_ref

--- a/subgrounds/schema.py
+++ b/subgrounds/schema.py
@@ -305,6 +305,17 @@ class TypeMeta:
                 TypeRef.T: The type reference for input field `fname`
             """
 
+            def print2(thing):
+                print(thing)
+                return thing
+            
+            for field in self.input_fields:
+                if field.name == fname:
+                    return field.type_
+
+                if field.type_ is TypeMeta.InputObjectMeta:
+                    field.name
+
             try:
                 return next(
                     self.input_fields

--- a/subgrounds/subgraph/fieldpath.py
+++ b/subgrounds/subgraph/fieldpath.py
@@ -686,7 +686,7 @@ class SyntheticField(FieldOperatorMixin):
                     def new_f(*args):
                         new_args = []
                         _counter = 0
-                        for (f_, deps) in acc:
+                        for f_, deps in acc:
                             match (f_, deps):
                                 case (None, FieldPath()):
                                     new_args.append(args[_counter])
@@ -705,7 +705,7 @@ class SyntheticField(FieldOperatorMixin):
                         return f(*new_args)
 
                     new_deps = []
-                    for (_, deps) in acc:
+                    for _, deps in acc:
                         match deps:
                             case FieldPath() as dep:
                                 new_deps.append(dep)

--- a/subgrounds/subgraph/subgraph.py
+++ b/subgrounds/subgraph/subgraph.py
@@ -47,7 +47,7 @@ class Subgraph:
         self._is_subgraph = is_subgraph
 
         # Add objects as attributes
-        for (key, obj) in self._schema.type_map.items():
+        for key, obj in self._schema.type_map.items():
             match obj:
                 case TypeMeta.ObjectMeta() | TypeMeta.InterfaceMeta():
                     super().__setattr__(key, Object(self, obj))

--- a/subgrounds/utils.py
+++ b/subgrounds/utils.py
@@ -4,10 +4,13 @@ Utility module for Subgrounds
 
 import platform
 from functools import cache
+from itertools import accumulate as _accumulate
 from itertools import filterfalse
 from typing import Any, Callable, Iterator, Optional, Tuple, TypeVar
 
 from pipe import Pipe, map
+
+accumulate = Pipe(_accumulate)
 
 
 def flatten(t):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -342,6 +342,48 @@ def schema(
                 ],
             ),
             "Token": token_objectmeta,
+            "Token_filter": TypeMeta.InputObjectMeta(
+                name="Token_filter",
+                description="",
+                inputFields=[
+                    TypeMeta.ArgumentMeta(
+                        name="id",
+                        description="",
+                        type=TypeRef.Named(name="String", kind="SCALAR"),
+                        defaultValue=None,
+                    ),
+                    TypeMeta.ArgumentMeta(
+                        name="id_gt",
+                        description="",
+                        type=TypeRef.Named(name="String", kind="SCALAR"),
+                        defaultValue=None,
+                    ),
+                    TypeMeta.ArgumentMeta(
+                        name="id_lt",
+                        description="",
+                        type=TypeRef.Named(name="String", kind="SCALAR"),
+                        defaultValue=None,
+                    ),
+                    TypeMeta.ArgumentMeta(
+                        name="symbol",
+                        description="",
+                        type=TypeRef.Named(name="String", kind="SCALAR"),
+                        defaultValue=None,
+                    ),
+                    TypeMeta.ArgumentMeta(
+                        name="symbol_gt",
+                        description="",
+                        type=TypeRef.Named(name="String", kind="SCALAR"),
+                        defaultValue=None,
+                    ),
+                    TypeMeta.ArgumentMeta(
+                        name="symbol_lt",
+                        description="",
+                        type=TypeRef.Named(name="String", kind="SCALAR"),
+                        defaultValue=None,
+                    ),
+                ],
+            ),
             "Pair": pair_objectmeta,
             "Pair_filter": TypeMeta.InputObjectMeta(
                 name="Pair_filter",
@@ -372,9 +414,21 @@ def schema(
                         defaultValue=None,
                     ),
                     TypeMeta.ArgumentMeta(
+                        name="token0_",
+                        description="",
+                        type=TypeRef.Named(name="Token_filter", kind="OBJECT"),
+                        defaultValue=None,
+                    ),
+                    TypeMeta.ArgumentMeta(
                         name="token1",
                         description="",
                         type=TypeRef.Named(name="String", kind="SCALAR"),
+                        defaultValue=None,
+                    ),
+                    TypeMeta.ArgumentMeta(
+                        name="token1_",
+                        description="",
+                        type=TypeRef.Named(name="Token_filter", kind="OBJECT"),
                         defaultValue=None,
                     ),
                     TypeMeta.ArgumentMeta(
@@ -434,6 +488,8 @@ def schema(
                     TypeMeta.EnumValueMeta(name="id", description=""),
                     TypeMeta.EnumValueMeta(name="reserveUSD", description=""),
                     TypeMeta.EnumValueMeta(name="createdAtTimestamp", description=""),
+                    TypeMeta.EnumValueMeta(name="token0__symbol", description=""),
+                    TypeMeta.EnumValueMeta(name="token1__symbol", description=""),
                 ],
             ),
         },

--- a/tests/pagination/test_preprocess.py
+++ b/tests/pagination/test_preprocess.py
@@ -1921,6 +1921,134 @@ def test_gen_pagination_nodes(
                 ),
             ),
         ),
+        (
+            queries.doc14(),
+            [
+                PaginationNode(
+                    0,
+                    "id",
+                    100,
+                    0,
+                    None,
+                    TypeRef.Named(name="String", kind="SCALAR"),
+                    ["pairs"],
+                    [],
+                )
+            ],
+            Document(
+                url="www.abc.xyz/graphql",
+                query=Query(
+                    name=None,
+                    selection=[
+                        Selection(
+                            fmeta=TypeMeta.FieldMeta(
+                                name="pairs",
+                                description="",
+                                args=[
+                                    TypeMeta.ArgumentMeta(
+                                        name="first",
+                                        description="",
+                                        type=TypeRef.Named(name="Int", kind="SCALAR"),
+                                        defaultValue=None,
+                                    ),
+                                    TypeMeta.ArgumentMeta(
+                                        name="skip",
+                                        description="",
+                                        type=TypeRef.Named(name="Int", kind="SCALAR"),
+                                        defaultValue=None,
+                                    ),
+                                    TypeMeta.ArgumentMeta(
+                                        name="where",
+                                        description="",
+                                        type=TypeRef.Named(
+                                            name="Pair_filter", kind="INPUT_OBJECT"
+                                        ),
+                                        defaultValue=None,
+                                    ),
+                                ],
+                                type=TypeRef.non_null_list("Pair", kind="OBJECT"),
+                            ),
+                            arguments=[
+                                Argument("first", InputValue.Variable("first0")),
+                                Argument("skip", InputValue.Variable("skip0")),
+                                Argument("orderBy", InputValue.Enum("token0__symbol")),
+                                Argument("orderDirection", InputValue.Enum("asc")),
+                                Argument(
+                                    "where",
+                                    InputValue.Object(
+                                        {
+                                            "token0": InputValue.Object(
+                                                {
+                                                    "symbol_gt": InputValue.Variable(
+                                                        "lastOrderingValue0"
+                                                    )
+                                                }
+                                            )
+                                        }
+                                    ),
+                                ),
+                            ],
+                            selection=[
+                                Selection(
+                                    fmeta=TypeMeta.FieldMeta(
+                                        name="name",
+                                        description="",
+                                        args=[],
+                                        type=TypeRef.Named(
+                                            name="String", kind="SCALAR"
+                                        ),
+                                    ),
+                                ),
+                                Selection(
+                                    fmeta=TypeMeta.FieldMeta(
+                                        name="id",
+                                        description="",
+                                        args=[],
+                                        type=TypeRef.Named(
+                                            name="String", kind="SCALAR"
+                                        ),
+                                    ),
+                                ),
+                                Selection(
+                                    fmeta=TypeMeta.FieldMeta(
+                                        name="token0",
+                                        description="",
+                                        args=[],
+                                        type=TypeRef.Named(
+                                            name="String", kind="SCALAR"
+                                        ),
+                                    ),
+                                    selection=[
+                                        Selection(
+                                            fmeta=TypeMeta.FieldMeta(
+                                                name="symbol",
+                                                description="",
+                                                args=[],
+                                                type=TypeRef.Named(
+                                                    name="String", kind="SCALAR"
+                                                ),
+                                            ),
+                                        )
+                                    ],
+                                ),
+                            ],
+                        )
+                    ],
+                    variables=[
+                        VariableDefinition(
+                            "first0", TypeRef.Named(name="Int", kind="SCALAR")
+                        ),
+                        VariableDefinition(
+                            "skip0", TypeRef.Named(name="Int", kind="SCALAR")
+                        ),
+                        VariableDefinition(
+                            "lastOrderingValue0",
+                            TypeRef.Named(name="String", kind="SCALAR"),
+                        ),
+                    ],
+                ),
+            ),
+        ),
     ],
 )
 def test_normalize_doc(

--- a/tests/pagination/test_strategies.py
+++ b/tests/pagination/test_strategies.py
@@ -38,7 +38,7 @@ def __test_args(
     data_and_exception: list[Tuple[dict[str, Any], Optional[Type]]],
 ):
     args_ = strategy.step()
-    for (args, (data, exn)) in zip(expected, data_and_exception):
+    for args, (data, exn) in zip(expected, data_and_exception):
         assert args_ == args
 
         if exn is not None:

--- a/tests/queries.py
+++ b/tests/queries.py
@@ -1,13 +1,4 @@
-import pytest
-
-from subgrounds.query import (
-    Argument,
-    Document,
-    InputValue,
-    Query,
-    Selection,
-    VariableDefinition,
-)
+from subgrounds.query import Argument, Document, InputValue, Query, Selection
 from subgrounds.schema import TypeMeta, TypeRef
 
 
@@ -1055,6 +1046,105 @@ def doc13():
                                 type=TypeRef.Named(name="String", kind="SCALAR"),
                             ),
                         )
+                    ],
+                )
+            ],
+        ),
+    )
+
+
+def doc14():
+    """
+    query {
+      liquidityPools(orderBy: outputToken__lastPriceUSD, orderDirection: desc) {
+        name
+        outputToken {
+          lastPriceUSD
+          name
+        }
+      }
+    }
+    """
+    return Document(
+        url="www.abc.xyz/graphql",
+        query=Query(
+            name=None,
+            selection=[
+                Selection(
+                    fmeta=TypeMeta.FieldMeta(
+                        name="pairs",
+                        description="",
+                        args=[
+                            TypeMeta.ArgumentMeta(
+                                name="first",
+                                description="",
+                                type=TypeRef.Named(name="Int", kind="SCALAR"),
+                                defaultValue=None,
+                            ),
+                            TypeMeta.ArgumentMeta(
+                                name="skip",
+                                description="",
+                                type=TypeRef.Named(name="Int", kind="SCALAR"),
+                                defaultValue=None,
+                            ),
+                            TypeMeta.ArgumentMeta(
+                                name="where",
+                                description="",
+                                type=TypeRef.Named(
+                                    name="Pair_filter", kind="INPUT_OBJECT"
+                                ),
+                                defaultValue=None,
+                            ),
+                        ],
+                        type=TypeRef.non_null_list("Pair", kind="OBJECT"),
+                    ),
+                    arguments=[
+                        Argument("orderBy", InputValue.Enum("token0__symbol")),
+                        Argument("orderDirection", InputValue.Enum("asc")),
+                        Argument(
+                            "where",
+                            InputValue.Object(
+                                {
+                                    "token0": InputValue.Object(
+                                        {
+                                            "symbol_gt": InputValue.Variable(
+                                                "lastOrderingValue0"
+                                            )
+                                        }
+                                    )
+                                }
+                            ),
+                        ),
+                    ],
+                    selection=[
+                        Selection(
+                            fmeta=TypeMeta.FieldMeta(
+                                name="name",
+                                description="",
+                                args=[],
+                                type=TypeRef.Named(name="String", kind="SCALAR"),
+                            ),
+                        ),
+                        Selection(
+                            fmeta=TypeMeta.FieldMeta(
+                                name="token0",
+                                description="",
+                                args=[],
+                                type=TypeRef.Named(name="String", kind="SCALAR"),
+                            ),
+                            selection=[
+                                Selection(
+                                    fmeta=TypeMeta.FieldMeta(
+                                        name="symbol",
+                                        description="",
+                                        args=[],
+                                        type=TypeRef.Named(
+                                            name="String", kind="SCALAR"
+                                        ),
+                                    ),
+                                )
+                            ],
+                        ),
                     ],
                 )
             ],

--- a/tests/test_subgraph.py
+++ b/tests/test_subgraph.py
@@ -1,8 +1,3 @@
-import unittest
-from ast import Sub
-
-import pytest
-
 from subgrounds.query import Argument, DataRequest, InputValue, Query, Selection
 from subgrounds.schema import SchemaMeta, TypeMeta, TypeRef
 from subgrounds.subgraph import FieldPath, Filter, Object, Subgraph, SyntheticField
@@ -210,6 +205,48 @@ def test_add_synthetic_field_1(subgraph: Subgraph):
                     ),
                 ],
             ),
+            "Token_filter": TypeMeta.InputObjectMeta(
+                name="Token_filter",
+                description="",
+                inputFields=[
+                    TypeMeta.ArgumentMeta(
+                        name="id",
+                        description="",
+                        type=TypeRef.Named(name="String", kind="SCALAR"),
+                        defaultValue=None,
+                    ),
+                    TypeMeta.ArgumentMeta(
+                        name="id_gt",
+                        description="",
+                        type=TypeRef.Named(name="String", kind="SCALAR"),
+                        defaultValue=None,
+                    ),
+                    TypeMeta.ArgumentMeta(
+                        name="id_lt",
+                        description="",
+                        type=TypeRef.Named(name="String", kind="SCALAR"),
+                        defaultValue=None,
+                    ),
+                    TypeMeta.ArgumentMeta(
+                        name="symbol",
+                        description="",
+                        type=TypeRef.Named(name="String", kind="SCALAR"),
+                        defaultValue=None,
+                    ),
+                    TypeMeta.ArgumentMeta(
+                        name="symbol_gt",
+                        description="",
+                        type=TypeRef.Named(name="String", kind="SCALAR"),
+                        defaultValue=None,
+                    ),
+                    TypeMeta.ArgumentMeta(
+                        name="symbol_lt",
+                        description="",
+                        type=TypeRef.Named(name="String", kind="SCALAR"),
+                        defaultValue=None,
+                    ),
+                ],
+            ),
             "Pair": TypeMeta.ObjectMeta(
                 name="Pair",
                 description="",
@@ -293,9 +330,21 @@ def test_add_synthetic_field_1(subgraph: Subgraph):
                         defaultValue=None,
                     ),
                     TypeMeta.ArgumentMeta(
+                        name="token0_",
+                        description="",
+                        type=TypeRef.Named(name="Token_filter", kind="OBJECT"),
+                        defaultValue=None,
+                    ),
+                    TypeMeta.ArgumentMeta(
                         name="token1",
                         description="",
                         type=TypeRef.Named(name="String", kind="SCALAR"),
+                        defaultValue=None,
+                    ),
+                    TypeMeta.ArgumentMeta(
+                        name="token1_",
+                        description="",
+                        type=TypeRef.Named(name="Token_filter", kind="OBJECT"),
                         defaultValue=None,
                     ),
                     TypeMeta.ArgumentMeta(
@@ -355,6 +404,8 @@ def test_add_synthetic_field_1(subgraph: Subgraph):
                     TypeMeta.EnumValueMeta(name="id", description=""),
                     TypeMeta.EnumValueMeta(name="reserveUSD", description=""),
                     TypeMeta.EnumValueMeta(name="createdAtTimestamp", description=""),
+                    TypeMeta.EnumValueMeta(name="token0__symbol", description=""),
+                    TypeMeta.EnumValueMeta(name="token1__symbol", description=""),
                 ],
             ),
             "Swap_filter": TypeMeta.InputObjectMeta(
@@ -622,6 +673,48 @@ def test_add_synthetic_field_2(subgraph: Subgraph):
                     ),
                 ],
             ),
+            "Token_filter": TypeMeta.InputObjectMeta(
+                name="Token_filter",
+                description="",
+                inputFields=[
+                    TypeMeta.ArgumentMeta(
+                        name="id",
+                        description="",
+                        type=TypeRef.Named(name="String", kind="SCALAR"),
+                        defaultValue=None,
+                    ),
+                    TypeMeta.ArgumentMeta(
+                        name="id_gt",
+                        description="",
+                        type=TypeRef.Named(name="String", kind="SCALAR"),
+                        defaultValue=None,
+                    ),
+                    TypeMeta.ArgumentMeta(
+                        name="id_lt",
+                        description="",
+                        type=TypeRef.Named(name="String", kind="SCALAR"),
+                        defaultValue=None,
+                    ),
+                    TypeMeta.ArgumentMeta(
+                        name="symbol",
+                        description="",
+                        type=TypeRef.Named(name="String", kind="SCALAR"),
+                        defaultValue=None,
+                    ),
+                    TypeMeta.ArgumentMeta(
+                        name="symbol_gt",
+                        description="",
+                        type=TypeRef.Named(name="String", kind="SCALAR"),
+                        defaultValue=None,
+                    ),
+                    TypeMeta.ArgumentMeta(
+                        name="symbol_lt",
+                        description="",
+                        type=TypeRef.Named(name="String", kind="SCALAR"),
+                        defaultValue=None,
+                    ),
+                ],
+            ),
             "Pair": TypeMeta.ObjectMeta(
                 name="Pair",
                 description="",
@@ -705,9 +798,21 @@ def test_add_synthetic_field_2(subgraph: Subgraph):
                         defaultValue=None,
                     ),
                     TypeMeta.ArgumentMeta(
+                        name="token0_",
+                        description="",
+                        type=TypeRef.Named(name="Token_filter", kind="OBJECT"),
+                        defaultValue=None,
+                    ),
+                    TypeMeta.ArgumentMeta(
                         name="token1",
                         description="",
                         type=TypeRef.Named(name="String", kind="SCALAR"),
+                        defaultValue=None,
+                    ),
+                    TypeMeta.ArgumentMeta(
+                        name="token1_",
+                        description="",
+                        type=TypeRef.Named(name="Token_filter", kind="OBJECT"),
                         defaultValue=None,
                     ),
                     TypeMeta.ArgumentMeta(
@@ -767,6 +872,8 @@ def test_add_synthetic_field_2(subgraph: Subgraph):
                     TypeMeta.EnumValueMeta(name="id", description=""),
                     TypeMeta.EnumValueMeta(name="reserveUSD", description=""),
                     TypeMeta.EnumValueMeta(name="createdAtTimestamp", description=""),
+                    TypeMeta.EnumValueMeta(name="token0__symbol", description=""),
+                    TypeMeta.EnumValueMeta(name="token1__symbol", description=""),
                 ],
             ),
             "Swap_filter": TypeMeta.InputObjectMeta(
@@ -1034,6 +1141,48 @@ def test_add_synthetic_field_3(subgraph: Subgraph):
                     ),
                 ],
             ),
+            "Token_filter": TypeMeta.InputObjectMeta(
+                name="Token_filter",
+                description="",
+                inputFields=[
+                    TypeMeta.ArgumentMeta(
+                        name="id",
+                        description="",
+                        type=TypeRef.Named(name="String", kind="SCALAR"),
+                        defaultValue=None,
+                    ),
+                    TypeMeta.ArgumentMeta(
+                        name="id_gt",
+                        description="",
+                        type=TypeRef.Named(name="String", kind="SCALAR"),
+                        defaultValue=None,
+                    ),
+                    TypeMeta.ArgumentMeta(
+                        name="id_lt",
+                        description="",
+                        type=TypeRef.Named(name="String", kind="SCALAR"),
+                        defaultValue=None,
+                    ),
+                    TypeMeta.ArgumentMeta(
+                        name="symbol",
+                        description="",
+                        type=TypeRef.Named(name="String", kind="SCALAR"),
+                        defaultValue=None,
+                    ),
+                    TypeMeta.ArgumentMeta(
+                        name="symbol_gt",
+                        description="",
+                        type=TypeRef.Named(name="String", kind="SCALAR"),
+                        defaultValue=None,
+                    ),
+                    TypeMeta.ArgumentMeta(
+                        name="symbol_lt",
+                        description="",
+                        type=TypeRef.Named(name="String", kind="SCALAR"),
+                        defaultValue=None,
+                    ),
+                ],
+            ),
             "Pair": TypeMeta.ObjectMeta(
                 name="Pair",
                 description="",
@@ -1123,9 +1272,21 @@ def test_add_synthetic_field_3(subgraph: Subgraph):
                         defaultValue=None,
                     ),
                     TypeMeta.ArgumentMeta(
+                        name="token0_",
+                        description="",
+                        type=TypeRef.Named(name="Token_filter", kind="OBJECT"),
+                        defaultValue=None,
+                    ),
+                    TypeMeta.ArgumentMeta(
                         name="token1",
                         description="",
                         type=TypeRef.Named(name="String", kind="SCALAR"),
+                        defaultValue=None,
+                    ),
+                    TypeMeta.ArgumentMeta(
+                        name="token1_",
+                        description="",
+                        type=TypeRef.Named(name="Token_filter", kind="OBJECT"),
                         defaultValue=None,
                     ),
                     TypeMeta.ArgumentMeta(
@@ -1185,6 +1346,8 @@ def test_add_synthetic_field_3(subgraph: Subgraph):
                     TypeMeta.EnumValueMeta(name="id", description=""),
                     TypeMeta.EnumValueMeta(name="reserveUSD", description=""),
                     TypeMeta.EnumValueMeta(name="createdAtTimestamp", description=""),
+                    TypeMeta.EnumValueMeta(name="token0__symbol", description=""),
+                    TypeMeta.EnumValueMeta(name="token1__symbol", description=""),
                 ],
             ),
             "Swap_filter": TypeMeta.InputObjectMeta(
@@ -1453,6 +1616,48 @@ def test_add_synthetic_field_4(subgraph: Subgraph):
                     ),
                 ],
             ),
+            "Token_filter": TypeMeta.InputObjectMeta(
+                name="Token_filter",
+                description="",
+                inputFields=[
+                    TypeMeta.ArgumentMeta(
+                        name="id",
+                        description="",
+                        type=TypeRef.Named(name="String", kind="SCALAR"),
+                        defaultValue=None,
+                    ),
+                    TypeMeta.ArgumentMeta(
+                        name="id_gt",
+                        description="",
+                        type=TypeRef.Named(name="String", kind="SCALAR"),
+                        defaultValue=None,
+                    ),
+                    TypeMeta.ArgumentMeta(
+                        name="id_lt",
+                        description="",
+                        type=TypeRef.Named(name="String", kind="SCALAR"),
+                        defaultValue=None,
+                    ),
+                    TypeMeta.ArgumentMeta(
+                        name="symbol",
+                        description="",
+                        type=TypeRef.Named(name="String", kind="SCALAR"),
+                        defaultValue=None,
+                    ),
+                    TypeMeta.ArgumentMeta(
+                        name="symbol_gt",
+                        description="",
+                        type=TypeRef.Named(name="String", kind="SCALAR"),
+                        defaultValue=None,
+                    ),
+                    TypeMeta.ArgumentMeta(
+                        name="symbol_lt",
+                        description="",
+                        type=TypeRef.Named(name="String", kind="SCALAR"),
+                        defaultValue=None,
+                    ),
+                ],
+            ),
             "Pair": TypeMeta.ObjectMeta(
                 name="Pair",
                 description="",
@@ -1536,9 +1741,21 @@ def test_add_synthetic_field_4(subgraph: Subgraph):
                         defaultValue=None,
                     ),
                     TypeMeta.ArgumentMeta(
+                        name="token0_",
+                        description="",
+                        type=TypeRef.Named(name="Token_filter", kind="OBJECT"),
+                        defaultValue=None,
+                    ),
+                    TypeMeta.ArgumentMeta(
                         name="token1",
                         description="",
                         type=TypeRef.Named(name="String", kind="SCALAR"),
+                        defaultValue=None,
+                    ),
+                    TypeMeta.ArgumentMeta(
+                        name="token1_",
+                        description="",
+                        type=TypeRef.Named(name="Token_filter", kind="OBJECT"),
                         defaultValue=None,
                     ),
                     TypeMeta.ArgumentMeta(
@@ -1598,6 +1815,8 @@ def test_add_synthetic_field_4(subgraph: Subgraph):
                     TypeMeta.EnumValueMeta(name="id", description=""),
                     TypeMeta.EnumValueMeta(name="reserveUSD", description=""),
                     TypeMeta.EnumValueMeta(name="createdAtTimestamp", description=""),
+                    TypeMeta.EnumValueMeta(name="token0__symbol", description=""),
+                    TypeMeta.EnumValueMeta(name="token1__symbol", description=""),
                 ],
             ),
             "Swap_filter": TypeMeta.InputObjectMeta(


### PR DESCRIPTION
Nested fields / selections can now be orderBy'd. This had a series of downstream effects which complicated this PR quite a bit.

Changes:
- Adjusted ordering, filtering, and querying (selections) to account for nested orderby and filtering values
- Updated tests to be able to test for nested orderby values

New:
- `accumulate` Pipe used in some tree-traversal
