### PR TITLE
fix: dsl-nested-orderby

### DIFF
--- a/subgrounds/subgraph/fieldpath.py
+++ b/subgrounds/subgraph/fieldpath.py
@@ -230,6 +230,7 @@ def fieldpaths_of_object(
                     yield subgraph.__getattribute__(object_.name).__getattribute__(
                         fmeta.name
                     ).id
+
                 case _:
                     yield subgraph.__getattribute__(object_.name).__getattribute__(
                         fmeta.name
@@ -456,13 +457,11 @@ class FieldPath(FieldOperatorMixin):
                 case ("where", [Filter(), *_] as filters):
                     return Filter.to_dict(filters)
                 case ("orderBy", FieldPath() as fpath):
-                    match fpath._leaf:
-                        case TypeMeta.FieldMeta() as fmeta:
-                            return fmeta.name
-                        case _:
-                            raise Exception(
-                                f"Cannot use non field {fpath} as orderBy argument"
-                            )
+                    if paths := fpath._name_path():
+                        return "__".join(paths)
+                    raise Exception(
+                        f"Cannot use empty paths as orderBy argument {fpath}"
+                    )
                 case _:
                     return raw_arg
 

--- a/tests/test_fieldpath.py
+++ b/tests/test_fieldpath.py
@@ -1,16 +1,6 @@
-import pytest
-
-from subgrounds.query import (
-    Argument,
-    DataRequest,
-    Document,
-    InputValue,
-    Query,
-    Selection,
-)
 from subgrounds.schema import TypeMeta, TypeRef
-from subgrounds.subgraph import FieldPath, Subgraph
-from subgrounds.subgrounds import Subgrounds
+from subgrounds.subgraph import FieldPath
+from tests.conftest import fieldpath_test_mode
 
 # from tests.conftest import *
 
@@ -86,8 +76,8 @@ def test_fieldpath_building_1(subgraph):
     )
     query = pairs.id
 
-    FieldPath.__test_mode = True
-    assert query == expected
+    with fieldpath_test_mode():
+        assert query == expected
 
 
 def test_fieldpath_building_2(subgraph):
@@ -228,8 +218,8 @@ def test_fieldpath_building_2(subgraph):
         selection=[subgraph.Pair.id, subgraph.Pair.reserveUSD],
     )
 
-    FieldPath.__test_mode = True
-    assert query == expected
+    with fieldpath_test_mode():
+        assert query == expected
 
 
 def test_fieldpath_building_3(subgraph):
@@ -371,5 +361,145 @@ def test_fieldpath_building_3(subgraph):
 
     query = [pairs.id, pairs.reserveUSD]
 
-    FieldPath.__test_mode = True
-    assert query == expected
+    with fieldpath_test_mode():
+        assert query == expected
+
+
+def test_fieldpath_building_4(subgraph):
+    expected = [
+        FieldPath(
+            subgraph,
+            TypeRef.Named(name="Query", kind="OBJECT"),
+            TypeRef.Named(name="String", kind="SCALAR"),
+            [
+                (
+                    {
+                        "first": 100,
+                        "orderBy": "token0__symbol",
+                        "orderDirection": "desc",
+                    },
+                    TypeMeta.FieldMeta(
+                        name="pairs",
+                        description="",
+                        args=[
+                            TypeMeta.ArgumentMeta(
+                                name="first",
+                                description="",
+                                type=TypeRef.Named(name="Int", kind="SCALAR"),
+                                defaultValue=None,
+                            ),
+                            TypeMeta.ArgumentMeta(
+                                name="skip",
+                                description="",
+                                type=TypeRef.Named(name="Int", kind="SCALAR"),
+                                defaultValue=None,
+                            ),
+                            TypeMeta.ArgumentMeta(
+                                name="where",
+                                description="",
+                                type=TypeRef.Named(
+                                    name="Pair_filter", kind="INPUT_OBJECT"
+                                ),
+                                defaultValue=None,
+                            ),
+                            TypeMeta.ArgumentMeta(
+                                name="orderBy",
+                                description="",
+                                type=TypeRef.Named(name="Pair_orderBy", kind="ENUM"),
+                                defaultValue=None,
+                            ),
+                            TypeMeta.ArgumentMeta(
+                                name="orderDirection",
+                                description="",
+                                type=TypeRef.Named(name="OrderDirection", kind="ENUM"),
+                                defaultValue=None,
+                            ),
+                        ],
+                        type=TypeRef.non_null_list("Pair", kind="OBJECT"),
+                    ),
+                ),
+                (
+                    None,
+                    TypeMeta.FieldMeta(
+                        name="id",
+                        description="",
+                        args=[],
+                        type=TypeRef.Named(name="String", kind="SCALAR"),
+                    ),
+                ),
+            ],
+        ),
+        FieldPath(
+            subgraph,
+            TypeRef.Named(name="Query", kind="OBJECT"),
+            TypeRef.Named(name="BigDecimal", kind="SCALAR"),
+            [
+                (
+                    {
+                        "first": 100,
+                        "orderBy": "token0__symbol",
+                        "orderDirection": "desc",
+                    },
+                    TypeMeta.FieldMeta(
+                        name="pairs",
+                        description="",
+                        args=[
+                            TypeMeta.ArgumentMeta(
+                                name="first",
+                                description="",
+                                type=TypeRef.Named(name="Int", kind="SCALAR"),
+                                defaultValue=None,
+                            ),
+                            TypeMeta.ArgumentMeta(
+                                name="skip",
+                                description="",
+                                type=TypeRef.Named(name="Int", kind="SCALAR"),
+                                defaultValue=None,
+                            ),
+                            TypeMeta.ArgumentMeta(
+                                name="where",
+                                description="",
+                                type=TypeRef.Named(
+                                    name="Pair_filter", kind="INPUT_OBJECT"
+                                ),
+                                defaultValue=None,
+                            ),
+                            TypeMeta.ArgumentMeta(
+                                name="orderBy",
+                                description="",
+                                type=TypeRef.Named(name="Pair_orderBy", kind="ENUM"),
+                                defaultValue=None,
+                            ),
+                            TypeMeta.ArgumentMeta(
+                                name="orderDirection",
+                                description="",
+                                type=TypeRef.Named(name="OrderDirection", kind="ENUM"),
+                                defaultValue=None,
+                            ),
+                        ],
+                        type=TypeRef.non_null_list("Pair", kind="OBJECT"),
+                    ),
+                ),
+                (
+                    None,
+                    TypeMeta.FieldMeta(
+                        name="reserveUSD",
+                        description="",
+                        args=[],
+                        type=TypeRef.Named(name="BigDecimal", kind="SCALAR"),
+                    ),
+                ),
+            ],
+        ),
+    ]
+
+    pairs = subgraph.Query.pairs(
+        first=100,
+        orderBy=subgraph.Pair.token0.symbol,
+        orderDirection="desc",
+    )
+
+    query = [pairs.id, pairs.reserveUSD]
+
+    with fieldpath_test_mode():
+        assert query == expected

--- a/tests/test_subgraph.py
+++ b/tests/test_subgraph.py
@@ -3,6 +3,7 @@ from subgrounds.schema import SchemaMeta, TypeMeta, TypeRef
 from subgrounds.subgraph import FieldPath, Filter, Object, Subgraph, SyntheticField
 from subgrounds.subgrounds import Subgrounds
 from subgrounds.utils import identity
+from tests.conftest import fieldpath_test_mode
 
 # class TestAddType(unittest.TestCase):
 #   def setUp(self):
@@ -1956,8 +1957,8 @@ def test_object(subgraph: Subgraph):
 
     Pair = subgraph.Pair
 
-    FieldPath.__test_mode = True
-    assert Pair == expected
+    with fieldpath_test_mode():
+        assert Pair == expected
 
 
 def test_field_path_1(subgraph: Subgraph):
@@ -2004,8 +2005,8 @@ def test_field_path_2(subgraph: Subgraph):
 
     fpath = subgraph.Pair.id
 
-    FieldPath.__test_mode = True
-    assert fpath == expected
+    with fieldpath_test_mode():
+        assert fpath == expected
 
 
 def test_field_path_3(subgraph: Subgraph):
@@ -2037,8 +2038,8 @@ def test_field_path_3(subgraph: Subgraph):
 
     fpath = subgraph.Pair.token0.id
 
-    FieldPath.__test_mode = True
-    assert fpath == expected
+    with fieldpath_test_mode():
+        assert fpath == expected
 
 
 def test_synthetic_field_path_1(subgraph: Subgraph):
@@ -2064,8 +2065,8 @@ def test_synthetic_field_path_1(subgraph: Subgraph):
     subgraph.Pair.reserveCAD = sfield
     fpath = subgraph.Pair.reserveCAD
 
-    FieldPath.__test_mode = True
-    assert fpath == expected
+    with fieldpath_test_mode():
+        assert fpath == expected
 
 
 def test_synthetic_field_path_2(subgraph: Subgraph):
@@ -2100,8 +2101,8 @@ def test_synthetic_field_path_2(subgraph: Subgraph):
     subgraph.Token.frenchName = sfield
     fpath = subgraph.Pair.token0.frenchName
 
-    FieldPath.__test_mode = True
-    assert fpath == expected
+    with fieldpath_test_mode():
+        assert fpath == expected
 
 
 def test_synthetic_field_path_3(subgraph: Subgraph):
@@ -2125,8 +2126,8 @@ def test_synthetic_field_path_3(subgraph: Subgraph):
     subgraph.Pair.token0Id = subgraph.Pair.token0.id
     fpath = subgraph.Pair.token0Id
 
-    FieldPath.__test_mode = True
-    assert fpath == expected
+    with fieldpath_test_mode():
+        assert fpath == expected
 
 
 def test_filter_1(subgraph: Subgraph):
@@ -2143,8 +2144,8 @@ def test_filter_1(subgraph: Subgraph):
 
     filter_ = subgraph.Pair.reserveUSD > 100
 
-    FieldPath.__test_mode = True
-    assert filter_ == expected
+    with fieldpath_test_mode():
+        assert filter_ == expected
 
 
 def test_field_path_args_1(subgraph: Subgraph):
@@ -2208,8 +2209,8 @@ def test_field_path_args_1(subgraph: Subgraph):
         orderDirection="desc",
     )
 
-    FieldPath.__test_mode = True
-    assert fpath == expected
+    with fieldpath_test_mode():
+        assert fpath == expected
 
 
 def test_field_path_args_2(subgraph: Subgraph):
@@ -2266,8 +2267,8 @@ def test_field_path_args_2(subgraph: Subgraph):
         where=[subgraph.Pair.reserveUSD > 100, subgraph.Pair.token0 == "abcd"],
     )
 
-    FieldPath.__test_mode = True
-    assert fpath == expected
+    with fieldpath_test_mode():
+        assert fpath == expected
 
 
 def test_field_path_args_3(subgraph: Subgraph):
@@ -2321,8 +2322,8 @@ def test_field_path_args_3(subgraph: Subgraph):
 
     fpath = subgraph.Query.pairs(first=100, orderBy=subgraph.Pair.reserveUSD)
 
-    FieldPath.__test_mode = True
-    assert fpath == expected
+    with fieldpath_test_mode():
+        assert fpath == expected
 
 
 def test_field_path_extend_1(subgraph: Subgraph):
@@ -2397,8 +2398,8 @@ def test_field_path_extend_1(subgraph: Subgraph):
 
     fpath = FieldPath._extend(fpath1, fpath2)
 
-    FieldPath.__test_mode = True
-    assert fpath == expected
+    with fieldpath_test_mode():
+        assert fpath == expected
 
 
 def test_mk_request_1(subgraph: Subgraph):
@@ -2489,8 +2490,8 @@ def test_mk_request_1(subgraph: Subgraph):
 
     req = sg.mk_request([pairs.id, pairs.token0.symbol])
 
-    FieldPath.__test_mode = True
-    assert req == expected
+    with fieldpath_test_mode():
+        assert req == expected
 
 
 def test_mk_request_2(sg: Subgrounds, subgraph: Subgraph):
@@ -2570,8 +2571,8 @@ def test_mk_request_2(sg: Subgrounds, subgraph: Subgraph):
 
     req = sg.mk_request([pairs.id, pairs.token0Id])
 
-    FieldPath.__test_mode = True
-    assert req == expected
+    with fieldpath_test_mode():
+        assert req == expected
 
 
 def test_mk_request_3(sg: Subgrounds, subgraph: Subgraph):
@@ -2649,8 +2650,8 @@ def test_mk_request_3(sg: Subgrounds, subgraph: Subgraph):
 
     req = sg.mk_request([subgraph.Query.swaps.timestamp, subgraph.Query.swaps.price])
 
-    FieldPath.__test_mode = True
-    assert req == expected
+    with fieldpath_test_mode():
+        assert req == expected
 
 
 def test_mk_request_4(sg: Subgrounds, subgraph: Subgraph):
@@ -2726,8 +2727,8 @@ def test_mk_request_4(sg: Subgrounds, subgraph: Subgraph):
 
     req = sg.mk_request([subgraph.Query.swaps.timestamp, subgraph.Query.swaps.my_value])
 
-    FieldPath.__test_mode = True
-    assert req == expected
+    with fieldpath_test_mode():
+        assert req == expected
 
 
 def test_synthetic_field_1(subgraph: Subgraph):


### PR DESCRIPTION
Prior to this commit, all FieldPath tests were passing due to a false positive with `__eq__`.

Note: ignore branch name