### PR TITLE
chore: trigger docs rebuild

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,19 @@
+name: Trigger Docs Rebuild
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - "**/*.md"
+
+jobs:
+  trigger-docs:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+            token: ${{ secrets.PAT }}
+            repository: 0xPlaygrounds/docs
+            event-type: my-event

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -16,4 +16,4 @@ jobs:
         with:
             token: ${{ secrets.PAT }}
             repository: 0xPlaygrounds/docs
-            event-type: my-event
+            event-type: trigger-rebuild

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ An intuitive python library for interfacing with Subgraphs.
 - **Simple**: Leverage a Pythonic API to easily build queries and transformations without the need for raw GraphQL manipulation.
 - **Automated**: Automatically handle pagination and schema introspection for effortless data retrieval.
 - **Powerful**: Create sophisticated queries using the `SyntheticFields` transformation system.
-
 <!-- end elevator-pitch -->
 
 ## Resources


### PR DESCRIPTION
This new job will trigger a docs rebuild when any `.md` file changes. ATM, only `changelog.md` is used on the docs but we might have more later!

This will allow new version updates to the repo to automagically build the docs keeping them "in-sync" ✨ 