### PR TITLE
feat: add helpers for accessing the playgrounds gateway

### DIFF
--- a/subgrounds/client.py
+++ b/subgrounds/client.py
@@ -124,7 +124,7 @@ def get_schema(url: str, headers: dict[str, Any]) -> dict[str, Any]:
     resp = requests.post(
         url,
         json={"query": INTROSPECTION_QUERY},
-        headers=default_header() | headers,
+        headers=default_header(url) | headers,
     )
 
     resp.raise_for_status()
@@ -179,7 +179,7 @@ def query(
             if variables == {}
             else {"query": query_str, "variables": variables}
         ),
-        headers=default_header() | headers,
+        headers=default_header(url) | headers,
     )
 
     resp.raise_for_status()

--- a/subgrounds/subgrounds.py
+++ b/subgrounds/subgrounds.py
@@ -63,14 +63,14 @@ class Subgrounds:
     subgraphs: dict[str, Subgraph] = field(default_factory=dict)
 
     @classmethod
-    def from_playgrounds_key(cls, pg_key: str):
-        if not pg_key.startswith("pg-"):
+    def from_pg_key(cls, key: str):
+        if not key.startswith("pg-"):
             raise SubgroundsError(
                 "Invalid Playgrounds Key: key should start with 'pg-'.\n\n"
                 f"Go to {PLAYGROUNDS_APP_URL} to double check your API Key!"
             )
 
-        return cls(headers={"Playgrounds-Api-Key": pg_key})
+        return cls(headers={"Playgrounds-Api-Key": key})
 
     def load(
         self,

--- a/subgrounds/subgrounds.py
+++ b/subgrounds/subgrounds.py
@@ -18,6 +18,7 @@ from pipe import groupby, map, traverse, where
 
 import subgrounds.client as client
 from subgrounds.dataframe_utils import df_of_json
+from subgrounds.errors import SubgroundsError
 from subgrounds.pagination import paginate, paginate_iter
 from subgrounds.pagination.pagination import PaginationStrategy
 from subgrounds.pagination.strategies import LegacyStrategy
@@ -31,6 +32,7 @@ from subgrounds.transform import (
     DocumentTransform,
     RequestTransform,
 )
+from subgrounds.utils import PLAYGROUNDS_APP_URL
 
 logger = logging.getLogger("subgrounds")
 warnings.simplefilter("default")
@@ -59,6 +61,16 @@ class Subgrounds:
         default_factory=lambda: DEFAULT_GLOBAL_TRANSFORMS
     )
     subgraphs: dict[str, Subgraph] = field(default_factory=dict)
+
+    @classmethod
+    def from_playgrounds_key(cls, pg_key: str):
+        if not pg_key.startswith("pg-"):
+            raise SubgroundsError(
+                "Invalid Playgrounds Key: key should start with 'pg-'.\n\n"
+                f"Go to {PLAYGROUNDS_APP_URL} to double check your API Key!"
+            )
+
+        return cls(headers={"Playgrounds-Api-Key": pg_key})
 
     def load(
         self,

--- a/subgrounds/utils.py
+++ b/subgrounds/utils.py
@@ -4,14 +4,13 @@ Utility module for Subgrounds
 
 import os
 import platform
+import warnings
 from functools import cache
 from itertools import accumulate as _accumulate
 from itertools import filterfalse
 from typing import Any, Callable, Iterator, Optional, Tuple, TypeVar
 
 from pipe import Pipe, map
-
-from subgrounds.errors import SubgroundsError
 
 PLAYGROUNDS_APP_URL = "https://app.playgrounds.network/"
 PLAYGROUNDS_API_URL = "https://api.playgrounds.network/"
@@ -221,13 +220,16 @@ def default_header(url: str):
 
     if url.startswith(PLAYGROUNDS_API_URL) and PLAYGROUNDS_ENV_VAR in os.environ:
         key = os.environ[PLAYGROUNDS_ENV_VAR]
-        if not key.startswith("pg-"):
-            raise SubgroundsError(
+        if key.startswith("pg-"):
+            return base | {"Playgrounds-Api-Key": key}
+
+        warnings.warn(
+            RuntimeWarning(
                 "Invalid Playgrounds Api Key at $PLAYGROUNDS_API_KEY:"
                 " Playgrounds api keys should start with 'pg-'.\n\n"
                 f"Go to {PLAYGROUNDS_APP_URL} to double check your API Key!"
             )
-        return base | {"Playgrounds-Api-Key": key}
+        )
 
     return base
 

--- a/subgrounds/utils.py
+++ b/subgrounds/utils.py
@@ -2,6 +2,7 @@
 Utility module for Subgrounds
 """
 
+import os
 import platform
 from functools import cache
 from itertools import accumulate as _accumulate
@@ -9,6 +10,12 @@ from itertools import filterfalse
 from typing import Any, Callable, Iterator, Optional, Tuple, TypeVar
 
 from pipe import Pipe, map
+
+from subgrounds.errors import SubgroundsError
+
+PLAYGROUNDS_APP_URL = "https://app.playgrounds.network/"
+PLAYGROUNDS_API_URL = "https://api.playgrounds.network/"
+PLAYGROUNDS_ENV_VAR = "PLAYGROUNDS_API_KEY"
 
 accumulate = Pipe(_accumulate)
 
@@ -201,10 +208,28 @@ def contains_list(data: dict | list | str | int | float | bool) -> bool:
 
 
 @cache
-def default_header():
-    """Contains the default header information for requests made by subgrounds"""
+def default_header(url: str):
+    """Contains the default header information for requests made by subgrounds
 
-    return {"Content-Type": "application/json", "User-Agent": user_agent()}
+    Inserts the Playgrounds API Key iff:
+      a) targetting the Playgrounds API
+      AND
+      b) if the `PLAYGROUNDS_API_KEY` environment variable is set
+    """
+
+    base = {"Content-Type": "application/json", "User-Agent": user_agent()}
+
+    if url.startswith(PLAYGROUNDS_API_URL) and PLAYGROUNDS_ENV_VAR in os.environ:
+        key = os.environ[PLAYGROUNDS_ENV_VAR]
+        if not key.startswith(PLAYGROUNDS_API_URL):
+            raise SubgroundsError(
+                "Invalid Playgrounds Api Key at $PLAYGROUNDS_API_KEY:"
+                " Playgrounds api keys should start with 'pg-'.\n\n"
+                f"Go to {PLAYGROUNDS_APP_URL} to double check your API Key!"
+            )
+        return base | {"Playgrounds-Api-Key": key}
+
+    return base
 
 
 @cache

--- a/subgrounds/utils.py
+++ b/subgrounds/utils.py
@@ -221,7 +221,7 @@ def default_header(url: str):
 
     if url.startswith(PLAYGROUNDS_API_URL) and PLAYGROUNDS_ENV_VAR in os.environ:
         key = os.environ[PLAYGROUNDS_ENV_VAR]
-        if not key.startswith(PLAYGROUNDS_API_URL):
+        if not key.startswith("pg-"):
             raise SubgroundsError(
                 "Invalid Playgrounds Api Key at $PLAYGROUNDS_API_KEY:"
                 " Playgrounds api keys should start with 'pg-'.\n\n"


### PR DESCRIPTION
- `$PLAYGROUNDS_API_KEY`
  - If set AND querying urls starting with https://api.playgrounds.network, injects correct auth header
  - Logic is apart of the `default_header` logic which sets user-agent, etc
- `Subgrounds.from_pg_key`
  - `classmethod` which provides an alternative constructor that takes in a playgrounds api key

I'm unsure on some naming here. Everything here was testing here manually:
```py
import os
os.environ["PLAYGROUNDS_API_KEY"] = "<my-key>"

from subgrounds import Subgrounds
sg = Subgrounds()
subgraph = sg.load_subgraph("https://api.playgrounds.network/v1/proxy/subgraphs/id/Ei5typKWPepPSgqkaKf3p5bPhgJesnu1RuRpyt69Pcrx")

sg = Subgrounds.from_pg_key("<my-key>")
```
_Observe no crashes_