### PR TITLE
Fix `add` method of `Selection` class

### DIFF
--- a/subgrounds/query.py
+++ b/subgrounds/query.py
@@ -783,6 +783,7 @@ class Selection:
                 return Selection(
                     fmeta=self.fmeta,
                     alias=self.alias,
+                    arguments=self.arguments,
                     selection=union(
                         self.selection,
                         new_selections,

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -240,7 +240,7 @@ def test_graphql_compilation(test_input: Query, expected: str):
                     type=TypeRef.non_null_list("Swap", kind="OBJECT"),
                 ),
                 None,
-                [],
+                [Argument("first", InputValue.Int(100))],
                 [
                     Selection(
                         TypeMeta.FieldMeta(
@@ -274,7 +274,7 @@ def test_graphql_compilation(test_input: Query, expected: str):
                     type=TypeRef.non_null_list("Swap", kind="OBJECT"),
                 ),
                 None,
-                [],
+                [Argument("first", InputValue.Int(100))],
                 [
                     Selection(
                         TypeMeta.FieldMeta(


### PR DESCRIPTION
**Issue introduced with [v1.5.1 (2023-05-15)](https://docs.playgrounds.network/subgrounds/changelog/#v1-5-1-2023-05-15)**

In the previous PR [#17](https://github.com/0xPlaygrounds/subgrounds/pull/17), modifications to the `_subgrounds/pagination/preprocess.py_` file introduced the use of `Selection.add` at 2 locations, intended to conserve the outer Selection arguments while adding subselections. However, the `add` method failed to retain the arguments of the outer selection.

Affected code sections:
- [Lines 272 to 282 in preprocess.py](https://github.com/0xPlaygrounds/subgrounds/blob/aea28e2083b08b7d905e94f504ffddd6849c081b/subgrounds/pagination/preprocess.py#L272-L282)
- [Lines 300 to 320 in preprocess.py](https://github.com/0xPlaygrounds/subgrounds/blob/aea28e2083b08b7d905e94f504ffddd6849c081b/subgrounds/pagination/preprocess.py#L300-L320)

**Impact:**
This issue results in the removal of all arguments that are not used in the pagination process. For example, the `block` (Block Height) argument, which allows selecting the block at which to return the data, is unintentionally removed. The queries are thus always run on the latest block available in the subgraph.

* Reproducible by for instance on an Ethereum Mainnet subgraph running a query with block = {"number" : 20000000} that do not fail and return the latest data available, while block 20000000 do not exist.

**Fix:**
To address this issue, the following actions were taken:
- Filled missing arguments property in the `Selection.add` method to ensure the retention of outer selection arguments.
- Fixed tests to verify the logic of arguments in the `Selection.add` method.

This PR resolves the problem and ensures that the pagination process functions as intended, preserving the necessary arguments while adding subselections.

**Recommandations:**

- Add tests that use other arguments such as the block height. This time travel feature of subgraphs is super important and widely used. It must be checked before any release.
- Tests by filling all arguments of objects in unit tests such as the `Selection.arguments` to detect such issues.
